### PR TITLE
Update to content 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@iconify/vue": "^3.2.1",
-    "@nuxt/content": "^2.0.0",
+    "@nuxt/content": "^2.0.1",
     "@nuxtjs/color-mode": "^3.0.3",
     "@nuxtjs/eslint-config-typescript": "^10.0.0",
     "@nuxtjs/tailwindcss": "^5.1.2",


### PR DESCRIPTION
I was wondering why nitro hooks weren't working, just had to update to 2.0.1