### PR TITLE
fix: correct title for GitHub icon

### DIFF
--- a/components/AppNavbar.vue
+++ b/components/AppNavbar.vue
@@ -20,7 +20,7 @@ const theme = useTheme()
     <!-- Social icons & Color Mode -->
     <div class="space-x-3 transition text-primary-500">
       <a v-if="theme.socials?.twitter" :href="`https://twitter.com/${theme.socials?.twitter}`" title="Twitter" class="dark:text-primary-100 hover:text-primary-700 dark:hover:text-primary-300"><Icon name="fa-brands:twitter" /></a>
-      <a v-if="theme.socials?.github" :href="`https://github.com/${theme.socials?.github}`" title="Twitter" class="dark:text-primary-100 hover:text-primary-700 dark:hover:text-primary-300"><Icon name="fa-brands:github" /></a>
+      <a v-if="theme.socials?.github" :href="`https://github.com/${theme.socials?.github}`" title="GitHub" class="dark:text-primary-100 hover:text-primary-700 dark:hover:text-primary-300"><Icon name="fa-brands:github" /></a>
       <ColorModeSwitch class="dark:text-primary-100 hover:text-primary-700 dark:hover:text-primary-300" />
     </div>
   </div>


### PR DESCRIPTION
This is intended to fix #21, which looks to be a minor copy 'n' paste error.

Resolves #21 