### PR TITLE
fix: broken links

### DIFF
--- a/template/content/1.index.md
+++ b/template/content/1.index.md
@@ -64,7 +64,7 @@ This is done thanks to the [`<ContentDoc>`](https://content.nuxtjs.org/api/compo
 
 ### Navigation
 
-The navigation is generated from your pages, you can take a look at the [`<Navbar>`](https://github.com/Atinux/content-wind/blob/main/components/Navbar.vue) component to see how it works.
+The navigation is generated from your pages, you can take a look at the [`<Navbar>`](https://github.com/Atinux/content-wind/blob/main/theme/components/Navbar.vue) component to see how it works.
 
 It uses the [`<ContentNavigation>`](https://content.nuxtjs.org/api/components/content-navigation) component from Nuxt Content to fetch the navigation object.
 
@@ -134,7 +134,7 @@ Learn more in the [Content Code Highlight section](https://content.nuxtjs.org/ap
 
 Add Vue components into the `components/content/` directory and start using them in Markdown.
 
-See the `<Alert>` component in [`components/content/Alert.vue`](https://github.com/Atinux/content-wind/blob/main/components/content/Alert.vue).
+See the `<Alert>` component in [`components/content/Alert.vue`](https://github.com/Atinux/content-wind/blob/main/theme/components/content/Alert.vue).
 
 By leveraging the [`<ContentSlot>`](https://content.nuxtjs.org/api/components/markdown) component from Nuxt Content, you can use both slots and props in Markdown thanks to the [MDC syntax](https://content.nuxtjs.org/guide/writing/mdc).
 
@@ -156,7 +156,7 @@ This is an alert
 This is the default content of my alert!
 ::
 
-If you want to go deeper, take a look at the [`<List>`](https://github.com/Atinux/content-wind/blob/main/components/content/List.vue) component to see some `useUnwrap()` magic :magic_wand:
+If you want to go deeper, take a look at the [`<List>`](https://github.com/Atinux/content-wind/blob/main/theme/components/content/List.vue) component to see some `useUnwrap()` magic :magic_wand:
 
 
 ## Deployment


### PR DESCRIPTION
Link pointing to component example are pointing to the wrong link