### PR TITLE
feat: list icon class

### DIFF
--- a/components/content/List.vue
+++ b/components/content/List.vue
@@ -6,6 +6,10 @@ defineProps({
   icon: {
     type: String,
     default: 'ph:check-circle-duotone'
+  },
+  iconClass: {
+    type: String,
+    default: ''
   }
 })
 </script>
@@ -13,7 +17,7 @@ defineProps({
 <template>
   <ul class="p-0">
     <li v-for="(item, index) of flatUnwrap($slots.default(), ['ul'])" :key="index" class="flex pl-0 space-x-2 my-1 items-center">
-      <Icon :name="icon" class="flex-shrink-0 w-6 h-6 mt-1 text-emerald-500" />
+      <Icon :name="icon" class="flex-shrink-0 w-6 h-6 mt-1 text-emerald-500" :class="iconClass" />
       <span><ContentSlot :use="() => item" unwrap="li" /></span>
     </li>
   </ul>


### PR DESCRIPTION
Add a `iconClass` prop for build-in `List` component, it's useful when user want to change list's icon color.