### PR TITLE
feat: add sr-only text for color switcher

### DIFF
--- a/components/ColorModeSwitch.vue
+++ b/components/ColorModeSwitch.vue
@@ -6,8 +6,14 @@ const onClick = () => (colorMode.value === 'light' ? (colorMode.preference = 'da
 <template>
   <button aria-label="Color Mode" class="inline-block w-5" @click="onClick">
     <ColorScheme placeholder="...">
-      <Icon v-if="colorMode.value === 'dark'" name="dark-mode" class="w-5 h-5" />
-      <Icon v-else name="light-mode" class="w-5 h-5" />
+      <template v-if="colorMode.value === 'dark'">
+        <Icon name="dark-mode" class="w-5 h-5" />
+        <span class="sr-only">Dark Mode</span>
+      </template>
+      <template v-else>
+        <Icon name="light-mode" class="w-5 h-5" />
+        <span class="sr-only">Light Mode</span>
+      </template>
     </ColorScheme>
   </button>
 </template>


### PR DESCRIPTION
I added 2 spans with `sr-only` for screen readers to know what that icon is for. Hope it helps.